### PR TITLE
BUG-2: Fix racer names visibility during race

### DIFF
--- a/race-frontend/src/components/RaceTrack.css
+++ b/race-frontend/src/components/RaceTrack.css
@@ -13,7 +13,8 @@
   padding: 20px;
   min-height: 350px;
   border: 3px solid #333;
-  overflow: hidden;
+  overflow-x: visible;
+  overflow-y: auto;
 }
 
 .empty-track {
@@ -40,6 +41,7 @@
   align-items: center;
   gap: 10px;
   z-index: 10;
+  max-width: calc(100% - 40px);
 }
 
 .racer-icon {
@@ -48,13 +50,22 @@
 }
 
 .racer-name {
-  background: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.95) !important;
+  color: #333 !important;
   padding: 5px 12px;
   border-radius: 20px;
   font-weight: 600;
   font-size: 14px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   white-space: nowrap;
+  position: relative;
+  z-index: 11;
+  min-width: fit-content;
+  pointer-events: none;
+  display: inline-block !important;
+  visibility: visible !important;
+  opacity: 1 !important;
+  text-shadow: none !important;
 }
 
 .finish-line {

--- a/race-frontend/src/components/RaceTrack.jsx
+++ b/race-frontend/src/components/RaceTrack.jsx
@@ -11,17 +11,22 @@ function RaceTrack({ raceState, onStartRace, onResetRace, isRaceRunning, disable
           <>
             {raceState.participants.map((participant) => {
               const percentage = Math.min((participant.position / finishLineDistance) * 100, 100)
+              // Ensure racer doesn't go beyond track bounds, accounting for name width
+              const maxLeft = 95 // Leave 5% for name visibility
+              const adjustedPercentage = Math.min(percentage, maxLeft)
               return (
                 <div key={participant.id} className="racer-lane">
                   <div
                     className="racer"
                     style={{
-                      left: `${percentage}%`,
+                      left: `${adjustedPercentage}%`,
                       transition: isRaceRunning ? 'left 0.1s linear' : 'none'
                     }}
                   >
                     <span className="racer-icon">{participant.icon}</span>
-                    <span className="racer-name">{participant.name}</span>
+                    <span className="racer-name" title={participant.name} style={{ color: '#333' }}>
+                      {participant.name}
+                    </span>
                   </div>
                 </div>
               )


### PR DESCRIPTION
Fixes issue #2

- Added explicit color styling to ensure names are visible
- Fixed overflow handling to prevent name clipping
- Added percentage cap to keep names on screen
- Improved z-index and visibility properties

Tested locally and confirmed working.